### PR TITLE
FAQ updates + bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This project includes a [DevContainer](https://containers.dev/) setup with Hugo,
 ### Local Server
 
 ```bash
+git submodule update --init --recursive
 hugo server --bind 0.0.0.0 --disableFastRender --noHTTPCache
 ```
 

--- a/content/faq/index.md
+++ b/content/faq/index.md
@@ -2,6 +2,7 @@
 title = "FAQ"
 description = "KaiOS FAQs"
 date = 2023-02-17T00:00:00+08:00
+lastmod = 2026-01-01T01:17:00+00:00
 toc = true
 draft = false
 unlisted = true
@@ -14,13 +15,13 @@ header_img = "img/home-alt.png"
 
 ### What hardware specifications do KaiOS phones have?
 
-* 240x320 ~2.4-3" displays
-* 256mb or 512mb RAM
-* 3G or 4G
+* 240x320 ~2.4-3.2" displays
+* 256mb, 512mb, or 1GB RAM
+* 3G, 4G, or 5G
 * ARM CPUs
   * Qualcomm, Spreadtrum & Mediatek
-  * ~1GHz - 1.3GHz
-  * Dual or Quad Core
+  * 1.0GHz - 2.0GHz
+  * Dual-core, Quad-core, or Octa-core
 * T9 or QWERTY keyboards
 * D-Pad & Soft-Key (LSK & RSK) navigation
 * WiFI & Bluetooth (optional)
@@ -29,16 +30,16 @@ header_img = "img/home-alt.png"
 
 No. KaiOS has a number of popular apps, including:
 
-* Facebook
-* WhatsApp
 * YouTube
 * Google Assistant
 * Google Search
 * Google Maps
 * Microsoft Outlook
 
-As of February 2023, most other popular social network, music streaming, chat, or shopping apps are not available. The following are **not officially available on KaiOS**:
+As of January 2026, most other popular social network, music streaming, chat, or shopping apps are not available. The following are **not officially available on KaiOS**:
 
+* Facebook
+* WhatsApp
 * Gmail (use default Email app)
 * Discord
 * Amazon
@@ -50,30 +51,34 @@ As of February 2023, most other popular social network, music streaming, chat, o
 
 ### Does KaiOS have group messaging?
 
-No, KaiOS does not support group text messages (SMS or MMS). Also KaiOS does not support Rich Communication Services (RCS) used by modern Android phones as a substitute for Apple's iMessage.
+Some KaiOS devices running 2.5.x do support group text messages (SMS and MMS), such as the [Cingular Flex 4G]({{< ref "all-kaios-phones#kaios-phones" >}} "KaiOS Phones"), however most do not. 
+
+All devices running KaiOS 3.0 or higher support group text messages (SMS and MMS). 
+
+All versions of KaiOS do not support Rich Communication Services (RCS) used by modern Android phones as a substitute for Apple's iMessage.
 
 ### Is KaiOS open source?
 
 KaiOS is a proprietary operating system based on Firefox OS, which was released under the "file-level" Mozilla Public License (MPL) 2.0. Parts of KaiOS source is available on [KaiOS Tech's GitHub](https://github.com/kaiostech/gecko-b2g).
 
-### What's the difference between KaiOS 2.5 and 3.0?
+### What's the difference between KaiOS 2.5, 3.X, and 4.0?
 
 Thanks to a combination of hardware and software upgrades, newer KaiOS 3.0 devices are noticeably smoother than older models running KaiOS 2.5. From a user perspective, there's little discernible difference. Most of the changes are under the hood. Here's a summary of key differences.
 
-|          | KaiOS 2.5     | KaiOS 3.0 |
-|--------------|-----------|------------|
-| Availability      | Global | US-only       |
-| Apps | 1300+      | 420        |
-| Gecko Engine | v48      | v84        |
-| ECMAScript      | ES2015 | ES2021       |
-| PWAs      | No | Yes       |
-| WebP      | No | Yes       |
-| App Origin      | `app://app_name.com` | `http://app_name.localhost`       |
-| Manifest      | `manifest.webapp` | `manifest.webmanifest`       |
-| WASM      | [asm.js](https://developer.mozilla.org/en-US/docs/Games/Tools/asm.js) | Yes       |
-| Debug Enabled      | Select Models | No       |
+|               | KaiOS 2.5                                                             | KaiOS 3.X                   | KaiOS 4.0                   |
+|---------------|-----------------------------------------------------------------------|-----------------------------|-----------------------------|
+| Availability  | Global                                                                | US-only                     | US-only                     |
+| Apps          | 1300+                                                                 | 420                         |                             |
+| Gecko Engine  | v48                                                                   | v84                         | v123                        |
+| ECMAScript    | ES2015                                                                | ES2021                      | ES2021                      |
+| PWAs          | No                                                                    | Yes                         | Yes                         |
+| WebP          | No                                                                    | Yes                         | Yes                         |
+| App Origin    | `app://app_name.com`                                                  | `http://app_name.localhost` | `http://app_name.localhost` |
+| Manifest      | `manifest.webapp`                                                     | `manifest.webmanifest`      | `manifest.webmanifest`      |
+| WASM          | [asm.js](https://developer.mozilla.org/en-US/docs/Games/Tools/asm.js) | Yes                         | Yes                         |
+| Debug Enabled | Select Models                                                         | No                          | No                          |
 
-<u>Note</u>: Many popular apps like Facebook and WhatsApp are not available on KaiOS 3.0. Additionally, you **cannot sideload apps on KaiOS 3.0** so it's not possible to debug apps on KaiOS 3.0 devices.
+<u>Note</u>: You **cannot sideload apps on KaiOS 3.X or KaiOS 4.0** so it's not possible to debug apps on KaiOS 3.X or KaiOS 4.0 devices.
 
 ### Can KaiOS 2.5 devices update to KaiOS 3.0?
 
@@ -85,7 +90,7 @@ No. It might be possible to port older versions of Android or MocorDroid to KaiO
 
 ### Is there a BlackBerry-like KaiOS phone with a QWERTY keyboard?
 
-There are two, the [JioPhone 2]({{< ref "whats-next-jiophone#jiophone-2" >}} "JioPhone 2")) (India-only), and the [Xandos X5](https://www.imei.info/phonedatabase/xandos-x5/) (3G only).
+There are two, the [JioPhone 2]({{< ref "whats-next-jiophone#jiophone-2" >}} "JioPhone 2") (India-only), and the [Xandos X5](https://www.imei.info/phonedatabase/xandos-x5/) (3G only).
 
 ### Can KaiOS run Android apps?
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -12,7 +12,7 @@
 
   <title>{{ $title }}</title>
 
-  {{- with .Site.Params.author }}
+  {{- with .Site.Params.author.name }}
   <meta name="author" content="{{ . }}">
   {{ end -}}
   <meta name="description" content="{{ .Description | default (.Summary | default .Site.Params.description ) }}">

--- a/layouts/_default/summary.html
+++ b/layouts/_default/summary.html
@@ -1,0 +1,18 @@
+<div class="post-preview">
+  <a href="{{ .RelPermalink }}">
+      <h2 class="post-title">{{ .Title }}</h2>
+      {{ with .Params.subtitle }}
+      <h3 class="post-subtitle">{{ . }}</h3>
+      {{ end }}
+      <div class="post-content-preview">
+        {{ if isset .Params "description" }} {{ index .Params "description" }}
+        {{ else }}
+        {{ .Summary | plainify | truncate 180 }}
+        {{ end }} 
+      </div>
+  </a>
+  <p class="post-meta">
+      Posted by {{ with $.Params.author }} {{ $.Params.author }} {{ else }} {{ .Site.Params.author.name }} {{ end }} on {{ .Date.Format "Mon, Jan 2, 2006" }}
+  </p>
+</div>
+<hr>

--- a/layouts/partials/intro-header.html
+++ b/layouts/partials/intro-header.html
@@ -25,7 +25,7 @@
           <h1>{{ .Title }}</h1>
           <h2 class="subheading">{{ $.Params.subtitle }}</h2>
           <span class="meta">
-            Posted by {{ with $.Params.author }} {{ $.Params.author }} {{ else }} {{ .Site.Params.author }} {{ end }}
+            Posted by {{ with $.Params.author }} {{ $.Params.author }} {{ else }} {{ .Site.Params.author.name }} {{ end }}
             on <time datetime="{{ .Date.Format "2006-01-02" }}">{{ .Date.Format "Jan 2, 2006" }}</time>
             {{ if not (eq .Lastmod .Date) }}
               (updated on <time datetime="{{ .Lastmod.Format "2006-01-02" }}">{{ .Lastmod.Format "Jan 2, 2006" }}</time>)


### PR DESCRIPTION
# FAQ Updates

I updated the FAQ page to reflect recent developents such as 

- Meta dropping support for WhatsApp on KaiOS
- Meta dropping support for Facebook on KaiOS
- KaiOS version 4.0 changes

Information about KaiOS 4.0 and device capabilities mostly came from this page https://www.tcl.com/us/en/products/mobile/flip-series/flip-4-5g and my own testing.

**NOTE**: I have no way to find the number of apps available for KaiOS 4.0 so I left it blank in the table under `### What's the difference between KaiOS 2.5, 3.X, and 4.0?` section. Please advise on what I should put here!

# Bug fix for author name on top of post

I fixed a bug in the author display, where the author display would display a `map[name:Tom Barrasso url:https://tombarrasso.com]` instead of just the name, in both `layouts/_default/baseof.html` and `layouts/partials/intro-header.html`.

~~**NOTE**: Unfortunately, I can't figure out how to get the fix for the post summary, as this lives only in `summary.html` which is in themes/puppet, which is the submodule. Please advise on how to proceed here!~~

I copied in the `summary.html` file from the `themes/puppet/layouts/_default/` directory to the `layouts/_default/` directory and modified the author reference to `.Site.Params.author.name` as with the other files


Before (screenshot from live version of kaios.dev):
<img width="716" height="234" alt="Screenshot 2025-12-31 at 8 23 35 PM" src="https://github.com/user-attachments/assets/7b42976f-5114-4deb-9a4c-47dae04771bc" />
<img width="732" height="209" alt="Screenshot 2025-12-31 at 9 21 20 PM" src="https://github.com/user-attachments/assets/e6d7135e-95b6-4274-9044-53bc8c53c697" />


After (screenshot from my local):
<img width="711" height="254" alt="Screenshot 2025-12-31 at 8 30 29 PM" src="https://github.com/user-attachments/assets/5bbfec9b-5603-4483-88f8-53fc92a65d98" />
<img width="654" height="241" alt="Screenshot 2025-12-31 at 9 22 06 PM" src="https://github.com/user-attachments/assets/c91de00c-e4c7-4528-857b-2ccd43e55d32" />


And here's one working with a different author as well, since that tests the first if condition

<img width="1684" height="414" alt="image" src="https://github.com/user-attachments/assets/e62e3b6c-9162-4cb7-83d5-de2e1e7e57ff" />
<img width="1474" height="606" alt="image" src="https://github.com/user-attachments/assets/8449aa12-ae2d-412d-954b-0ad55ebcc431" />


# README.md update

I added the `git submodule update --init --recursive` command to the `### Local Server` section of the README.md

# Testing

i ran the `hugo` command to run the server locally, and observed all my changes working as expected.
